### PR TITLE
Fix Issue 65-66, broken category filter and wincondition sort

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -44,6 +44,7 @@ import { NgbdModalContent } from './components/project-list/project-list.compone
 import { MatSnackBarModule } from '@angular/material';
 import { SnackbarService } from './services/snackbar.service';
 import { WinConditionFilterPipe } from './pipes/win-condition-filter.pipe';
+import { WinConditionSortPipe } from './pipes/win-condition-sort.pipe';
 
 @NgModule({
   declarations: [
@@ -74,7 +75,8 @@ import { WinConditionFilterPipe } from './pipes/win-condition-filter.pipe';
     RegisterComponent,
     AddProjectComponent,
     NgbdModalContent,
-    WinConditionFilterPipe
+    WinConditionFilterPipe,
+    WinConditionSortPipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { AddProjectComponent } from './components/add-project/add-project.compon
 import { NgbdModalContent } from './components/project-list/project-list.component';
 import { MatSnackBarModule } from '@angular/material';
 import { SnackbarService } from './services/snackbar.service';
+import { WinConditionFilterPipe } from './pipes/win-condition-filter.pipe';
 
 @NgModule({
   declarations: [
@@ -72,7 +73,8 @@ import { SnackbarService } from './services/snackbar.service';
     ServiceTesterComponent,
     RegisterComponent,
     AddProjectComponent,
-    NgbdModalContent
+    NgbdModalContent,
+    WinConditionFilterPipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/category-holder/category-holder.component.html
+++ b/src/app/components/category-holder/category-holder.component.html
@@ -4,7 +4,7 @@
     </p>
     <form id="category-form" [formGroup]="categoryForm" (ngSubmit)="applyCategory()">
         <label formArrayName="categories" *ngFor="let category of categories">
-          <input type="checkbox">
+          <input type="checkbox" (change)="handleCheck($event, category)">
           <span id="category-name" [ngStyle]="{'background-color': addHashToCategory(category.color) }">{{category.name}} <span [hidden]="category.type!='mmf'"> (MMF)</span></span>
           <i class="fas fa-times" id="delete-category" (click)="deleteCategory()"></i>
         </label>

--- a/src/app/components/category-holder/category-holder.component.ts
+++ b/src/app/components/category-holder/category-holder.component.ts
@@ -15,8 +15,6 @@ export class CategoryHolderComponent implements OnInit {
   categories: Category[];
   categoriesSelected = new Set<Category>();
 
-  @Output() applyCategoryToWin = new EventEmitter<Array<Category>>();
-
   constructor(private formBuilder: FormBuilder, private categoryService: CategoryService, private router:Router) {
     this.categoryService.getCategories.subscribe((data) => {
         this.categories = data;

--- a/src/app/components/category-holder/category-holder.component.ts
+++ b/src/app/components/category-holder/category-holder.component.ts
@@ -13,7 +13,7 @@ export class CategoryHolderComponent implements OnInit {
 
   categoryForm: FormGroup;
   categories: Category[];
-  categoriesSelected = [];
+  categoriesSelected = new Set<Category>();
 
   @Output() applyCategoryToWin = new EventEmitter<Array<Category>>();
 
@@ -31,11 +31,7 @@ export class CategoryHolderComponent implements OnInit {
   }
 
   applyCategory() {
-    const selectedOrderIds = this.categoryForm.value.categories
-      .map((v, i) => v ? this.categories[i] : null)
-      .filter(v => v !== null);
-    this.applyCategoryToWin.emit(selectedOrderIds);
-    console.log(this.categoryForm.value.categories.map((v, i) => v ? this.categories[i] : null));
+    this.categoryService.setSelectedCategories(Array.from(this.categoriesSelected));
   }
 
   ngOnInit() {
@@ -62,6 +58,15 @@ export class CategoryHolderComponent implements OnInit {
 
         this.addCheckboxes();
       }
+  }
+
+  handleCheck(event, category) {
+    const checked = event.target.checked;
+    if (checked) {
+      this.categoriesSelected.add(category);
+    } else {
+      this.categoriesSelected.delete(category);
+    }
   }
 
   addHashToCategory(categoryStr: string) {

--- a/src/app/components/project-benefits/project-benefits.component.html
+++ b/src/app/components/project-benefits/project-benefits.component.html
@@ -84,6 +84,6 @@
 
         </div>
     </div>
-    <app-category-holder class="col-3" style="margin-left: 7rem;" (applyCategoryToWin)="onCategoryChange($event)"></app-category-holder>
+    <app-category-holder class="col-3" style="margin-left: 7rem;"></app-category-holder>
 
 </div>

--- a/src/app/components/project-wins/project-wins.component.html
+++ b/src/app/components/project-wins/project-wins.component.html
@@ -1,2 +1,2 @@
 <app-win-holder class="col-9"></app-win-holder>
-<app-category-holder class="col-3" (applyCategoryToWin) = "onCategoryChange($event)"></app-category-holder>
+<app-category-holder class="col-3"></app-category-holder>

--- a/src/app/components/project-wins/project-wins.component.ts
+++ b/src/app/components/project-wins/project-wins.component.ts
@@ -9,19 +9,9 @@ import { WinHolderComponent } from '../win-holder/win-holder.component';
 
 
 export class ProjectWinsComponent implements OnInit {
-  @ViewChild(WinHolderComponent, { static: false }) winHolder: WinHolderComponent;
-
   constructor() { }
 
   ngOnInit() {
-  }
-
-  onCategoryChange(event) {
-    const res =  new Array<string>();
-    event.forEach(element => {
-      res.push(element.name);
-    });
-    this.winHolder.categorize(res);
   }
 
 }

--- a/src/app/components/win-holder/win-holder.component.html
+++ b/src/app/components/win-holder/win-holder.component.html
@@ -1,3 +1,3 @@
-<app-win-input (addWinCondition)="createWinConditionHandler($event)" [currentCategory]="currentCategory"></app-win-input>
+<app-win-input></app-win-input>
 <app-sort-dropdown class="mr-5" id="sort-dropdown" [sortStates]="sortStates" [currentSortState]="currentSortState" (currentSortStateChange)="handleSortState($event)"></app-sort-dropdown>
 <app-win-condition *ngFor="let winCondition of winConditions | winConditionFilter: selectedCategories | winConditionSort: currentSortState" [winCondition]="winCondition"></app-win-condition>

--- a/src/app/components/win-holder/win-holder.component.html
+++ b/src/app/components/win-holder/win-holder.component.html
@@ -1,3 +1,3 @@
-<app-win-input (addWinCondition)="createWinConditionHandler($event)" [currentCategory]="currentCategory" (currentCategoryChange)="sort($event)"></app-win-input>
-<app-sort-dropdown class="mr-5" id="sort-dropdown" [sortStates]="sortStates" [currentSortState]="currentSortState" (currentSortStateChange)="sort($event)"></app-sort-dropdown>
-<app-win-condition *ngFor="let winCondition of winConditions | winConditionFilter: selectedCategories" [winCondition]="winCondition"></app-win-condition>
+<app-win-input (addWinCondition)="createWinConditionHandler($event)" [currentCategory]="currentCategory"></app-win-input>
+<app-sort-dropdown class="mr-5" id="sort-dropdown" [sortStates]="sortStates" [currentSortState]="currentSortState" (currentSortStateChange)="handleSortState($event)"></app-sort-dropdown>
+<app-win-condition *ngFor="let winCondition of winConditions | winConditionFilter: selectedCategories | winConditionSort: currentSortState" [winCondition]="winCondition"></app-win-condition>

--- a/src/app/components/win-holder/win-holder.component.html
+++ b/src/app/components/win-holder/win-holder.component.html
@@ -1,3 +1,3 @@
 <app-win-input (addWinCondition)="createWinConditionHandler($event)" [currentCategory]="currentCategory" (currentCategoryChange)="sort($event)"></app-win-input>
 <app-sort-dropdown class="mr-5" id="sort-dropdown" [sortStates]="sortStates" [currentSortState]="currentSortState" (currentSortStateChange)="sort($event)"></app-sort-dropdown>
-<app-win-condition *ngFor="let winCondition of winConditions" [winCondition]="winCondition"></app-win-condition>
+<app-win-condition *ngFor="let winCondition of winConditions | winConditionFilter: selectedCategories" [winCondition]="winCondition"></app-win-condition>

--- a/src/app/components/win-holder/win-holder.component.ts
+++ b/src/app/components/win-holder/win-holder.component.ts
@@ -41,11 +41,6 @@ export class WinHolderComponent implements OnInit, OnDestroy {
     this.currentSortState = state;
   }
 
-  createWinConditionHandler(pEvent) {
-    var newWinCondition = pEvent;
-    this.winConditions = this.createWinCondition(newWinCondition, this.winConditions);
-  }
-
   createWinCondition(pWinCondition, pWinConditions) {
     var clonePWinConditions = pWinConditions.slice(0);
     clonePWinConditions.push(pWinCondition);

--- a/src/app/components/win-holder/win-holder.component.ts
+++ b/src/app/components/win-holder/win-holder.component.ts
@@ -33,48 +33,17 @@ export class WinHolderComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.sortStates = ["MostLikes", "LeastLikes"];
-    this.currentSortState = "MostLikes";
+    this.sortStates = ["Most Likes", "Least Likes"];
+    this.currentSortState = "Most Likes";
   }
 
-  sortByMostLikes(pWinConditions) {
-    var clonePWinConditions = pWinConditions.slice(0);
-    clonePWinConditions.sort(function(a, b){
-      var aTotalVotes = a.upvoters.length - a.downvoters.length;
-      var bTotalVotes = b.upvoters.length - b.downvoters.length;
-      return bTotalVotes - aTotalVotes;
-    });
-    return clonePWinConditions;
+  handleSortState(state) {
+    this.currentSortState = state;
   }
-
-  sortByLeastLikes(pWinConditions) {
-    var clonePWinConditions = pWinConditions.slice(0);
-    clonePWinConditions.sort(function(a, b){
-      var aTotalVotes = a.upvoters.length - a.downvoters.length;
-      var bTotalVotes = b.upvoters.length - b.downvoters.length;
-      return aTotalVotes - bTotalVotes;
-    });
-    return clonePWinConditions;
-  }
-
-
-  sort() {
-
-    // TODO: This wont work if we don't re-request the data from the backend after each vote, which will be too heavy for the server.
-    // We should somehow use the votecomponent score to sort the win conditions. Idea: use viewchildren to get score from wincondition component.
-    if(this.currentSortState == "MostLikes"){
-      this.winConditions = this.sortByMostLikes(this.winConditions);
-    }
-    else if(this.currentSortState  == "LeastLikes"){
-      this.winConditions = this.sortByLeastLikes(this.winConditions);
-    }
-  }
-
 
   createWinConditionHandler(pEvent) {
     var newWinCondition = pEvent;
     this.winConditions = this.createWinCondition(newWinCondition, this.winConditions);
-    this.sort();
   }
 
   createWinCondition(pWinCondition, pWinConditions) {

--- a/src/app/components/win-holder/win-holder.component.ts
+++ b/src/app/components/win-holder/win-holder.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { WinCondition } from '../../classes/win-condition';
-import { categories } from '../category-holder/dummyCategories';
 import { WinconditionService } from 'src/app/services/wincondition.service';
 import { Subscription } from 'rxjs';
+import { CategoryService } from 'src/app/services/category.service';
+import { Category } from 'src/app/classes/category';
 
 @Component({
   selector: 'app-win-holder',
@@ -13,24 +14,26 @@ export class WinHolderComponent implements OnInit, OnDestroy {
 
   sortStates;
   currentSortState;
-  categories;
   currentCategory;
   winConditionsArray;
   origWinConditions;
+  selectedCategories: Array<Category>;
   private wSub: Subscription;
+  private cSub: Subscription;
   public winConditions: Array<WinCondition>;
 
-  constructor(private winconditionService: WinconditionService) {
+  constructor(private winconditionService: WinconditionService, private categoryService: CategoryService) {
     this.wSub = this.winconditionService.winConditionData.subscribe((data: Array<WinCondition>) => {
       this.winConditions = data;
-      this.sort();
+    });
+
+    this.cSub = this.categoryService.getSelectedCategories.subscribe((data) => {
+      this.selectedCategories = data;
     });
   }
 
   ngOnInit() {
     this.sortStates = ["MostLikes", "LeastLikes"];
-    this.categories = categories;
-    this.currentCategory = "None";
     this.currentSortState = "MostLikes";
   }
 
@@ -67,19 +70,6 @@ export class WinHolderComponent implements OnInit, OnDestroy {
     }
   }
 
-  categorize(currentCategoryChange : Array<string>){
-    return;
-    if (currentCategoryChange.length===0) {
-      this.winConditions = this.origWinConditions.slice();
-      return;
-    }
-    this.winConditions = this.origWinConditions.filter((item) => {
-            return item.categories.find((cat) => {
-                return currentCategoryChange.includes(cat.name);
-            });
-
-    });
-  }
 
   createWinConditionHandler(pEvent) {
     var newWinCondition = pEvent;
@@ -95,6 +85,7 @@ export class WinHolderComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.wSub.unsubscribe();
+    this.cSub.unsubscribe();
   }
 
 

--- a/src/app/components/win-input/win-input.component.ts
+++ b/src/app/components/win-input/win-input.component.ts
@@ -19,10 +19,7 @@ export class WinInputComponent implements OnInit {
 
   addWinForm : FormGroup
   private categories: Array<Category>;
-  @Input() currentCategory: string;
   @ViewChild('multiSelectx', {static:false}) multiSelect;
-
-  @Output() addWinCondition = new EventEmitter<WinCondition>();
 
   dropdownList = [];
   selectedItems = [];

--- a/src/app/components/win-input/win-input.component.ts
+++ b/src/app/components/win-input/win-input.component.ts
@@ -22,7 +22,6 @@ export class WinInputComponent implements OnInit {
   @Input() currentCategory: string;
   @ViewChild('multiSelectx', {static:false}) multiSelect;
 
-  @Output() currentCategoryChange = new EventEmitter<string>();
   @Output() addWinCondition = new EventEmitter<WinCondition>();
 
   dropdownList = [];
@@ -37,12 +36,6 @@ export class WinInputComponent implements OnInit {
       this.addWinForm = this.fb.group({
       winpost: ['',[Validators.required,Validators.minLength(4)]]
     })
-   }
-
-   changeCategory(pCategory) {
-     this.currentCategory = pCategory;
-     this.currentCategoryChange.emit(pCategory);
-     this.dropdownList = this.categories;
    }
 
   ngOnInit() {

--- a/src/app/pipes/win-condition-filter.pipe.spec.ts
+++ b/src/app/pipes/win-condition-filter.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { WinConditionFilterPipe } from './win-condition-filter.pipe';
+
+describe('WinConditionFilterPipe', () => {
+  it('create an instance', () => {
+    const pipe = new WinConditionFilterPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/win-condition-filter.pipe.ts
+++ b/src/app/pipes/win-condition-filter.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Category } from '../classes/category';
+import { WinCondition } from '../classes/win-condition';
+
+@Pipe({
+  name: 'winConditionFilter'
+})
+export class WinConditionFilterPipe implements PipeTransform {
+
+  transform(winConditions: WinCondition[], categories: Category[]): any {
+    const selectedIds = categories.map((category) => category.id);
+    if (!winConditions) {
+      return [];
+    }
+    if (categories.length === 0) {
+      return winConditions;
+    }
+
+    return  winConditions.filter((winCondition) => {
+      return winCondition.categories.find((cat) => {
+          return selectedIds.includes(cat.id);
+      });
+    });
+  }
+
+}

--- a/src/app/pipes/win-condition-sort.pipe.spec.ts
+++ b/src/app/pipes/win-condition-sort.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { WinConditionSortPipe } from './win-condition-sort.pipe';
+
+describe('WinConditionSortPipe', () => {
+  it('create an instance', () => {
+    const pipe = new WinConditionSortPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/win-condition-sort.pipe.ts
+++ b/src/app/pipes/win-condition-sort.pipe.ts
@@ -1,0 +1,31 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { WinCondition } from '../classes/win-condition';
+
+@Pipe({
+  name: 'winConditionSort'
+})
+export class WinConditionSortPipe implements PipeTransform {
+
+  transform(winconditions: WinCondition[], sortState: string ): any {
+    if (sortState === 'Most Likes') {
+      return this.sortByLikes(winconditions, true);
+    } else {
+      return this.sortByLikes(winconditions, false);
+    }
+  }
+
+  sortByLikes(winConditions, asc: boolean) {
+    const cloneWinConditions = winConditions.slice(0);
+    cloneWinConditions.sort((a, b) => {
+      const aTotalVotes = a.upvoters.length - a.downvoters.length;
+      const bTotalVotes = b.upvoters.length - b.downvoters.length;
+      if (asc) {
+        return bTotalVotes - aTotalVotes;
+      } else {
+        return aTotalVotes - bTotalVotes;
+      }
+    });
+    return cloneWinConditions;
+  }
+
+}

--- a/src/app/services/category.service.ts
+++ b/src/app/services/category.service.ts
@@ -14,6 +14,8 @@ export class CategoryService {
   private activeProjectId;
   private categoryData = new BehaviorSubject<Category[]>([]);
   getCategories = this.categoryData.asObservable();
+  private selectedCategoriesData = new BehaviorSubject<Category[]>([]);
+  getSelectedCategories = this.selectedCategoriesData.asObservable();
   constructor(private backendService: BackendService, private projectService: ProjectService) {
     this.projectService.getActiveProjectId.subscribe((projectId)=>{
         this.getAllCategories(projectId);
@@ -40,5 +42,9 @@ export class CategoryService {
       categoryArr.push(data);
       this.categoryData.next(categoryArr);
     });
+  }
+
+  setSelectedCategories(categories: Category[]) {
+    this.selectedCategoriesData.next(categories);
   }
 }


### PR DESCRIPTION
Created selected categories set in the category holder, updated that whenever a new category is selected/unselected. When user clicks filter, this set is sent to the category service as an array, which is kept in a BehaviorSubject. Win Holder subscribes to that this and applies a filter to the winconditions according to the categories

Wincondition sort is moved to the pipe which removes the need for constantly calling sort etc functions