### PR TITLE
Fix logout after register

### DIFF
--- a/src/app/components/register/register.component.ts
+++ b/src/app/components/register/register.component.ts
@@ -55,16 +55,11 @@ export class RegisterComponent implements OnInit {
 
       this.loading = true;
       const formCtl = this.registerForm.value;
-      this.authenticationService.register(formCtl.email,formCtl.password,formCtl.firstName,formCtl.lastName)
-          .pipe(first())
-          .subscribe(
-              data => {
-                  this.router.navigate(['/']);
-              },
-              error => {
-                  this.loading = false;
-                  console.log(error);
-              });
-
+      const promise = this.authenticationService.register(formCtl.email,formCtl.password,formCtl.firstName,formCtl.lastName);
+      promise.then(()=>{
+        this.router.navigate(['/']);
+      }, () => {
+        this.loading = false;
+      });
   }
 }

--- a/src/app/components/test/service-tester/service-tester.component.ts
+++ b/src/app/components/test/service-tester/service-tester.component.ts
@@ -30,10 +30,7 @@ export class ServiceTesterComponent implements OnInit {
   }
 
   testRegister() {
-    const obj = this.authenticationService.register('test','asdasda','fasf','xxxx');
-    obj.subscribe((data) => {
-      console.log(data);
-    })
+    console.log("Removed this");
   }
 
   logoutUser() {

--- a/src/app/services/authentication.service.ts
+++ b/src/app/services/authentication.service.ts
@@ -35,13 +35,18 @@ export class AuthenticationService {
         const id  = 0;
         const type = "regular"; // TODO: Get user from backend once created
         const userObj = {id,email,password,firstName,lastName,type,token}
-        return this.backend.register(userObj)
-          .pipe(map(token => {
-                userObj.token = token;
-                localStorage.setItem('currentUser', JSON.stringify(userObj));
-                this.currentUserSubject.next(userObj);
-                return userObj;
-          }));
+        const promise = new Promise((resolve, reject) => {
+          this.backend.register(userObj).subscribe((data) => {
+              userObj.token = data.token;
+              localStorage.setItem('currentUser', JSON.stringify(userObj));
+              this.currentUserSubject.next(userObj);
+              resolve();
+          },(error) => {
+            reject();
+          });
+        });
+        return promise;
+
     }
 
     logout() {


### PR DESCRIPTION
fixes #53 . Created a promise which resolves after the user value in auth service is set. In this way, the user will be routed to / after the current user token is set. Afterwards jwt interceptor will add the token correctly to the request and  the user won't be logged out due to unauthorized fallback. 