### PR TITLE
fix project change stuck category

### DIFF
--- a/src/app/components/category-holder/category-holder.component.ts
+++ b/src/app/components/category-holder/category-holder.component.ts
@@ -26,7 +26,7 @@ export class CategoryHolderComponent implements OnInit, OnDestroy {
         this.categories = data;
     });
 
-    this.pSub = this.projectService.activeProjectData.subscribe((data) => {
+    this.pSub = this.projectService.getActiveProjectId.subscribe((data) => {
       this.categoriesSelected.clear();
       this.applyCategory();
     });

--- a/src/app/components/category-holder/category-holder.component.ts
+++ b/src/app/components/category-holder/category-holder.component.ts
@@ -1,4 +1,6 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { ProjectService } from 'src/app/services/project/project.service';
+import { Component, EventEmitter, OnInit, Output, OnDestroy } from '@angular/core';
 import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Category } from 'src/app/classes/category';
 import { CategoryService } from 'src/app/services/category.service';
@@ -9,15 +11,24 @@ import { Router } from '@angular/router';
   templateUrl: './category-holder.component.html',
   styleUrls: ['./category-holder.component.css']
 })
-export class CategoryHolderComponent implements OnInit {
+export class CategoryHolderComponent implements OnInit, OnDestroy {
 
   categoryForm: FormGroup;
   categories: Category[];
   categoriesSelected = new Set<Category>();
+  cSub: Subscription;
+  pSub: Subscription;
 
-  constructor(private formBuilder: FormBuilder, private categoryService: CategoryService, private router:Router) {
-    this.categoryService.getCategories.subscribe((data) => {
+  constructor(private formBuilder: FormBuilder,
+              private categoryService: CategoryService,
+              private projectService: ProjectService) {
+    this.cSub = this.categoryService.getCategories.subscribe((data) => {
         this.categories = data;
+    });
+
+    this.pSub = this.projectService.activeProjectData.subscribe((data) => {
+      this.categoriesSelected.clear();
+      this.applyCategory();
     });
   }
 
@@ -72,6 +83,11 @@ export class CategoryHolderComponent implements OnInit {
   }
 
   deleteCategory() {
+  }
+
+  ngOnDestroy(): void {
+    this.cSub.unsubscribe();
+    this.pSub.unsubscribe();
   }
 
 }

--- a/src/app/services/project/project.service.ts
+++ b/src/app/services/project/project.service.ts
@@ -20,11 +20,11 @@ const PUTPROJECT_URL = environment.urlBase + '/project';
 export class ProjectService {
 
   initialProject = new Project("Waiting..",0,"Waiting..","public","Waiting...",false,false,0,0,0,new Date(),new Date());
-  public joinedProjectListData = new BehaviorSubject<Project[]>([]);
+  private joinedProjectListData = new BehaviorSubject<Project[]>([]);
   joinedProjectList = this.joinedProjectListData.asObservable();
   private otherProjectListData = new BehaviorSubject<Project[]>([]);
   otherProjectList = this.otherProjectListData.asObservable();
-  public activeProjectData = new BehaviorSubject<number>(-1);
+  private activeProjectData = new BehaviorSubject<number>(-1);
   getActiveProjectId = this.activeProjectData.asObservable();
   private activeProjectObjectData = new BehaviorSubject<Project>(this.initialProject);
   getActiveProjectObject = this.activeProjectObjectData.asObservable();


### PR DESCRIPTION
There is a bug in category filtering. Go to project A, filter win conditions, go to project B, nothing shows up, because we don't reset the active categories when the project changes.  This fixes it 